### PR TITLE
Anpassung `name` Attribut

### DIFF
--- a/app/VersionScan.php
+++ b/app/VersionScan.php
@@ -400,7 +400,7 @@ class VersionScan
         }
 
         $report = [
-            'name'         => 'CMSVersion',
+            'name'         => 'CMSVERSION',
             'version'      => file_get_contents(base_path('VERSION')),
             'hasError'     => false,
             'errorMessage' => null,


### PR DESCRIPTION
Wir nutzen für den Scanner `name` die uppercased Version, sodass dieses Kürzel direkt für die Translations und BLA-Repos weiterverwendet werden kann.