### PR TITLE
Anpassung der API-Rückgabe für CMS-Versionen die nicht 100% festellbar sind

### DIFF
--- a/app/Console/Commands/ScanWebsite.php
+++ b/app/Console/Commands/ScanWebsite.php
@@ -65,7 +65,7 @@ class ScanWebsite extends Command
             ($result["CMS"] === null) ? 'CMS: Unknown' : 'CMS: ' . $result["CMS"]
         );
 
-        $this->info($result["Versions"] === null ? 'Version: Unknown' : '');
+        $this->info($result["Versions"] === null ? 'Version: Unknown' : 'Detected Versions:');
 
         foreach ($result["Versions"] as $version => $details) {
             $this->info("Version: " . $version);
@@ -73,7 +73,7 @@ class ScanWebsite extends Command
                 ($details["IsLatest"] === null) ? 'Is Latest: Unknown' : 'Is Latest: ' . ($details["IsLatest"] ? 'true' : 'false')
             );
             $this->info(
-                ($details["Latest"] === null) ? 'Latest: Unknown' : 'Latest: ' . ($details["Latest"] ? 'true' : 'false')
+                ($details["Latest"] === null) ? 'Latest: Unknown' : 'Latest: ' . ($details["Latest"] ? $details["Latest"] : 'false')
             );
             $this->info(
                 ($details["Supported"] === null) ? 'Is Supported: Unknown' : 'Is Supported: ' . ($details["Supported"] ? 'true' : 'false')

--- a/app/Console/Commands/ScanWebsite.php
+++ b/app/Console/Commands/ScanWebsite.php
@@ -64,17 +64,21 @@ class ScanWebsite extends Command
         $this->info(
             ($result["CMS"] === null) ? 'CMS: Unknown' : 'CMS: ' . $result["CMS"]
         );
-        $this->info(
-            ($result["Version"] === null) ? 'Version: Unknown' : 'Version: ' . $result["Version"]
-        );
-        $this->info(
-            ($result["IsLatest"] === null) ? 'Is Latest: Unknown' : 'Is Latest: ' . $result["IsLatest"]
-        );
-        $this->info(
-            ($result["Latest"] === null) ? 'Latest: Unknown' : 'Latest: ' . $result["Latest"]
-        );
-        $this->info(
-            ($result["Supported"] === null) ? 'Is Supported: Unknown' : 'Is Supported: ' . $result["Supported"]
-        );
+
+        $this->info($result["Versions"] === null ? 'Version: Unknown' : '');
+
+        foreach ($result["Versions"] as $version => $details) {
+            $this->info("Version: " . $version);
+            $this->info(
+                ($details["IsLatest"] === null) ? 'Is Latest: Unknown' : 'Is Latest: ' . ($details["IsLatest"] ? 'true' : 'false')
+            );
+            $this->info(
+                ($details["Latest"] === null) ? 'Latest: Unknown' : 'Latest: ' . ($details["Latest"] ? 'true' : 'false')
+            );
+            $this->info(
+                ($details["Supported"] === null) ? 'Is Supported: Unknown' : 'Is Supported: ' . ($details["Supported"] ? 'true' : 'false')
+            );
+            $this->info('=======================');
+        }
     }
 }

--- a/app/VersionScan.php
+++ b/app/VersionScan.php
@@ -415,8 +415,8 @@ class VersionScan
                     "placeholder" => "CMS_OUTDATED",
                     "values" => [
                         "cms" => $this->result["CMS"],
-                        "version" => $details["Supported"],
-                        "latest" => $details["IsLatest"]
+                        "version" => implode(', ', array_keys($this->result["Versions"])),
+                        "latest" => $this->result["Versions"][key($this->result["Versions"])]['Latest']
                     ]
                 ]
             ];
@@ -432,7 +432,7 @@ class VersionScan
                     "placeholder" => "CMS_OUT_OF_SUPPORT",
                     "values" => [
                         "cms" => $this->result["CMS"],
-                        "version" => $version
+                        "version" => implode(', ', array_keys($this->result["Versions"]))
                     ]
                 ]
             ];
@@ -448,7 +448,7 @@ class VersionScan
                     "placeholder" => "CMS_MIGHT_UPTODATE",
                     "values" => [
                         "cms" => $this->result["CMS"],
-                        "version" => $version
+                        "version" => implode(', ', array_keys($this->result["Versions"]))
                     ]
                 ]
             ];


### PR DESCRIPTION
Dieser PR bezieht sich auf das erstellte [https://github.com/SIWECOS/Version-Scanner/issues/2](url) Issue.

## Problemstellung
Wenn die Version nicht eindeutig identifiziert werden konnte, weil mehrere Versionen zur Auswahl standen, wurde keine entsprechende Warnmeldung wiedergegeben.

## Lösung
Für den Fall, dass die Version nicht eindeutig identifizierbar ist, wurde nun der Programmcode angepasst und ein weiterer "Case" hinzugefügt: Sollte eine Version up-to-date sein, die anderen jedoch outdated, so wird eine spezifische Warnmeldung zurückgegeben und der Score angepasst.