### PR TITLE
Translation-Fix

### DIFF
--- a/app/VersionScan.php
+++ b/app/VersionScan.php
@@ -502,7 +502,7 @@ class VersionScan
             'score'        => $score,
             'tests'        => [
                 [
-                    "name" => "VERSION",
+                    "name" => "CMSVERSION",
                     "errorMessage" => null,
                     "hasError" => false,
                     "score" => $score,


### PR DESCRIPTION
Der `scanner_code` lautet: `VERSION`

Der Test für den `VERSION`-Scanner lautet `CMSVERSION`.

Entweder wir übernehmen die Namensgebung hier so oder ändern dies im `translations`-Repo.

Eindeutiger und genauer finde ich aber diese Variante.